### PR TITLE
Fixed shutdown bug in Issue #2.

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -14,7 +14,6 @@ import sqlite3
 import datetime
 import sys
 
-global shutdown
 shutdown = False
 
 # Load the submission ID's from posts that have already been processed.
@@ -55,6 +54,7 @@ def already_processed_comments():
 
 # Determine what the comment is and the needed response
 def find_penny_comment(flat_comments, processing, mods):
+    global shutdown
     replied = False
     reply = ''
     # Don't care about where the comments are so flatten the comment tree
@@ -727,7 +727,6 @@ def find_penny_comment(flat_comments, processing, mods):
 
                     #Emergency shutdown
                     elif current.startswith("shutdown"):
-                        shutdown = False
                         print(commentauthor)
                         if commentauthor in mods or commentauthor == "Weerdo5255":
                             reply = "Emergency Shutdown Initiated! Bye!"


### PR DESCRIPTION
Fixes #2 issue.

---

Shutdown wasn't working regardless of the presented bug, making the `find_penny_comment()` method access the global `shutdown` variable makes the shutdown command work.

---

Bug itself was due to the re-defining of `shutdown` as `False`, removing the line fixes it.

---

Full explanation in the [issue discussion](https://github.com/CGWilliam/PennyBot/issues/2#issuecomment-231822354).
